### PR TITLE
Update package.json to match with the license

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To find out more about how contributing to Jantick repos work check out out [CON
 <!-- LICENSE -->
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information.
+Distributed under the GNU-GPT License. See `LICENSE` for more information.
 
 
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "MIT",
+  "license": "GPL",
   "dependencies": {
     "common-tags": "^1.8.0",
     "discord.js": "^12.4.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "common-tags": "^1.8.0",
     "discord.js": "^12.4.1",


### PR DESCRIPTION
In package.json, its licensed with the ISC license, but the license used is MIT -- leading to confusion on what is the actual license.